### PR TITLE
feat: state repo restore, Brave API key, Tailscale cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,16 @@ TELEGRAM_ALLOWED_IDS=
 # GitHub personal access token (optional — enables gh CLI on remote VM)
 # Create at https://github.com/settings/tokens (classic, repo scope)
 # GH_TOKEN=
+
+# Brave Search API key (optional — enables web search tool)
+# Get one at https://brave.com/search/api/ (Data for Search plan)
+# BRAVE_API_KEY=
+
+# Tailscale auth key (optional — enables Tailscale SSH access to the VM)
+# Generate at https://login.tailscale.com/admin/settings/keys
+# TAILSCALE_AUTHKEY=
+
+# State repo for workspace backup/restore (optional)
+# Private repo (SSH URL) used to restore workspace on fresh volumes.
+# Agent pushes backups here periodically; entrypoint restores on volume loss.
+# STATE_REPO=git@github.com:user/agent-state.git

--- a/README.md
+++ b/README.md
@@ -85,6 +85,39 @@ make deploy
 
 The token is picked up automatically — no interactive `gh auth login` needed.
 
+### State Backup & Restore (Optional)
+
+Protect agent state (memory, workspace files, config) against volume loss with a private Git repo.
+
+1. Create a private repo (e.g., `your-user/agent-state`)
+2. Add the SSH key from `vm-setup.sh` as a deploy key with **write access**
+3. Set the Fly secret:
+
+```bash
+fly secrets set STATE_REPO='git@github.com:your-user/agent-state.git' -a my-clawd
+make deploy
+```
+
+**How it works:**
+
+- The agent pushes workspace snapshots to the repo periodically (cron job)
+- On fresh volume deployments, the entrypoint detects no existing state and restores from the repo
+- Existing volumes are never affected — restore only triggers when `MEMORY.md` is absent
+
+**Repo structure:**
+
+```
+agent-state/
+├── workspace/
+│   ├── MEMORY.md
+│   ├── memory/
+│   ├── AGENTS.md
+│   ├── SOUL.md
+│   └── ...
+└── config/
+    └── openclaw.json
+```
+
 ## Configuration
 
 ### Model


### PR DESCRIPTION
## Changes

### State repo backup/restore (`STATE_REPO`)

Adds an optional `STATE_REPO` env var (SSH git URL) for disaster recovery. On fresh volume deploys (detected by absence of `MEMORY.md`), the entrypoint clones the state repo and restores workspace files + config before the gateway starts.

This pairs with an agent-level cron job that periodically pushes workspace snapshots to the repo. The infra side only handles the **restore** path — backup is agent behavior.

**No-op when `STATE_REPO` is unset.** Existing deployments are unaffected.

### Brave Search API key

`BRAVE_API_KEY` is now wired through `entrypoint.sh` into `.env.secrets`, enabling the `web_search` tool when the secret is set.

### Tailscale cleanup

Stale `/data/tailscaled.state` file (from pre-statedir deploys) is cleaned up after migration.

### .env.example

Added commented-out entries for `BRAVE_API_KEY`, `TAILSCALE_AUTHKEY`, and `STATE_REPO`.

### README

Documented the state backup/restore workflow.

## Files changed

- `remote/entrypoint.sh` — state restore step, Brave key, Tailscale cleanup, renumbered steps
- `.env.example` — new optional secrets
- `README.md` — state backup/restore section

Closes #2 (items 1, 3, 4, 5)
