### PR TITLE
feat: bump VM to tier 1 — 4 vCPU / 8GB RAM / 10GB disk

### DIFF
--- a/remote/fly.toml.example
+++ b/remote/fly.toml.example
@@ -6,16 +6,16 @@ primary_region = "{{REGION}}"
 
 [env]
   FLY_APP_NAME = "{{APP_NAME}}"
-  NODE_OPTIONS = "--max-old-space-size=2048"
+  NODE_OPTIONS = "--max-old-space-size=4096"
 
 [mounts]
   source = "clawd_data"
   destination = "/data"
-  initial_size = "3gb"
+  initial_size = "10gb"
 
 [[vm]]
-  size = "shared-cpu-2x"
-  memory = "4gb"
+  size = "shared-cpu-4x"
+  memory = "8gb"
 
 [[restart]]
   policy = "always"


### PR DESCRIPTION
Upgrades the fly.toml template from shared-cpu-2x/4GB/3GB to shared-cpu-4x/8GB/10GB.

Also bumps `NODE_OPTIONS --max-old-space-size` from 2048 to 4096 to match the new RAM.

**What this unlocks:**
- QMD memory search (needs ~2GB for 3 GGUF models)
- JS monorepo builds (Next.js, Turborepo — npm install can spike to 2-3GB)
- Light ML inference (CLIP, MobileNet for hCaptcha classifier)
- Multiple browser contexts simultaneously
- Comfortable headroom for gateway + browser + Python + Node

**Estimated cost delta:** ~$15-20/month more on Fly.io.

**Note:** Volume size change (`initial_size`) only applies to new volumes. Existing volumes need to be extended separately via `fly volumes extend`.