### PR TITLE
feat: auto-deploy to Fly.io on merge to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy to Fly.io
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "**.md"
+      - ".pre-commit-config.yaml"
+      - ".prettierrc"
+      - ".prettierignore"
+      - "CLAUDE.md"
+      - "CODEX.md"
+      - "AGENTS.md"
+
+concurrency:
+  group: deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to Fly.io
+        run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
Adds a GitHub Actions workflow that deploys to Fly.io on every push to `main`.

## How it works

- Triggers on push to `main`, skips docs-only changes
- Uses `flyctl deploy --remote-only` (builds on Fly's builders, no Docker needed in CI)
- `concurrency` group prevents overlapping deploys

## Setup required

1. Generate a Fly.io deploy token:
   ```bash
   fly tokens create deploy -a <app-name>
   ```
2. Add it as a GitHub Actions secret: `FLY_API_TOKEN`
3. Ensure `fly.toml` is committed to the repo root (currently only `fly.toml.example` exists — either commit the real one or generate it in CI via `make fly-init`)

## Notes

- The entrypoint already handles config patching without overwriting agent-managed state, so redeploys are safe
- Path filter skips `.md` files, `.prettierrc`, and agent instruction files to avoid unnecessary deploys on docs changes

Closes #1