### PR TITLE
fix: complete ACP config and pre-enable acpx plugin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,13 +76,24 @@ If `STATE_REPO` is set (as a Fly secret), the remote VM automatically syncs live
 
 The image includes [Claude Code](https://www.npmjs.com/package/@anthropic-ai/claude-code) and [Codex](https://www.npmjs.com/package/@openai/codex) CLIs so OpenClaw can spawn coding agent sessions via ACP.
 
-**Config:** `acp` section in `config/openclaw.json`:
+**Config:** `acp` section in `config/openclaw.json`. The `acpx` plugin must also be enabled in `plugins.entries` — without it, the gateway doctor auto-enables the plugin at runtime, triggering a restart loop:
 
 ```json
 {
+  "plugins": {
+    "entries": {
+      "acpx": { "enabled": true }
+    }
+  },
   "acp": {
+    "enabled": true,
+    "dispatch": { "enabled": true },
+    "backend": "acpx",
     "defaultAgent": "codex",
-    "allowedAgents": ["codex", "claude"]
+    "allowedAgents": ["codex", "claude"],
+    "maxConcurrentSessions": 4,
+    "stream": { "coalesceIdleMs": 300, "maxChunkChars": 1200 },
+    "runtime": { "ttlMinutes": 120 }
   }
 }
 ```

--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -29,6 +29,9 @@
       },
       "slack": {
         "enabled": true
+      },
+      "acpx": {
+        "enabled": true
       }
     }
   },
@@ -101,8 +104,19 @@
     }
   },
   "acp": {
+    "enabled": true,
+    "dispatch": { "enabled": true },
+    "backend": "acpx",
     "defaultAgent": "codex",
-    "allowedAgents": ["codex", "claude"]
+    "allowedAgents": ["codex", "claude"],
+    "maxConcurrentSessions": 4,
+    "stream": {
+      "coalesceIdleMs": 300,
+      "maxChunkChars": 1200
+    },
+    "runtime": {
+      "ttlMinutes": 120
+    }
   },
   "hooks": {
     "internal": {


### PR DESCRIPTION
## Summary

- **Root cause**: The `acp` config block was incomplete (missing `enabled`, `backend`, `dispatch` fields) and the `acpx` plugin wasn't declared in `plugins.entries`. The gateway's internal doctor detected these issues at runtime and auto-fixed them — each fix triggering a gateway restart that broke the Telegram channel connection.
- **Fix**: Pre-configure the full ACP schema and acpx plugin entry so the doctor has nothing to fix at startup. Also create the extensions directory in the entrypoint and patch ACP/acpx settings on every deploy.
- **Config reference**: Based on the [OpenClaw ACP Agents docs](https://docs.openclaw.ai/tools/acp-agents) — the full schema requires `enabled`, `backend: "acpx"`, `dispatch.enabled`, `maxConcurrentSessions`, `stream`, and `runtime.ttlMinutes`.

## Changes

| File | What |
|------|------|
| `config/openclaw.json` | Complete `acp` block + add `acpx` to `plugins.entries` |
| `remote/entrypoint.sh` | Create extensions dir (step 1), patch ACP+acpx in jq infra-patch (step 4), re-enable acpx after doctor (step 11) |
| `CLAUDE.md` | Document full ACP config schema with acpx plugin requirement |

## Test plan

- [ ] Deploy to Fly.io and verify gateway starts without restart loop in logs
- [ ] Confirm Telegram bot responds to DMs after deploy
- [ ] Verify `openclaw doctor` shows no ACP/acpx issues (`make fly-console` → `openclaw doctor`)
- [ ] Test ACP session spawn (e.g., "run this in Codex") if OPENAI_API_KEY is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)