### PR TITLE
fix: use chown instead of chmod 777 for acpx extensions

### DIFF
--- a/remote/Dockerfile
+++ b/remote/Dockerfile
@@ -65,8 +65,7 @@ RUN curl -fsSL https://bun.sh/install | bash \
 # OpenClaw + QMD memory backend
 # chmod: node-llama-cpp needs write access for CPU backend build at runtime (runs as agent user)
 RUN npm install -g openclaw@latest @tobilu/qmd@latest \
-    && chmod -R a+w /usr/lib/node_modules/@tobilu/qmd/node_modules/node-llama-cpp/ \
-    && chmod -R a+w /usr/lib/node_modules/openclaw/extensions/acpx/
+    && chmod -R a+w /usr/lib/node_modules/@tobilu/qmd/node_modules/node-llama-cpp/
 
 # ACP harnesses (Claude Code + Codex CLIs for agent coding sessions)
 RUN npm install -g @anthropic-ai/claude-code@latest @openai/codex@latest
@@ -74,6 +73,9 @@ RUN npm install -g @anthropic-ai/claude-code@latest @openai/codex@latest
 # Non-root user with sudo
 RUN groupadd -r agent && useradd -r -g agent -m -s /bin/bash agent \
     && echo "agent ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/agent
+
+# Fix acpx plugin ownership — OpenClaw blocks world-writable extensions dirs
+RUN chown -R agent:agent /usr/lib/node_modules/openclaw/extensions/acpx/ 2>/dev/null || true
 
 # Bundle config, workspace, and cron defaults
 COPY config/openclaw.json /opt/openclaw/openclaw.json

--- a/remote/entrypoint.sh
+++ b/remote/entrypoint.sh
@@ -234,6 +234,8 @@ chmod 700 /data/.openclaw /data/.claude /data/.codex /data/.ssh /data/.gnupg /da
 chmod 600 /data/.openclaw/openclaw.json
 [ -s /data/.ssh/id_ed25519 ] && chmod 600 /data/.ssh/id_ed25519
 chown -R agent:agent /data/.openclaw /data/.claude /data/.codex /data/.ssh /data/git /data/.gnupg /data/logs /data/.env.secrets /home/agent/.bashrc
+# acpx plugin dir must be owned by agent — OpenClaw blocks world-writable extensions
+chown -R agent:agent /usr/lib/node_modules/openclaw/extensions/acpx/ 2>/dev/null || true
 
 # --- 10. Tailscale (optional) ---
 if [ -n "${TAILSCALE_AUTHKEY:-}" ]; then


### PR DESCRIPTION
## Summary

- **Problem**: The Dockerfile used `chmod -R a+w` (world-writable) on the acpx extensions directory. OpenClaw blocks world-writable extensions dirs for security, causing the gateway doctor to fix permissions and trigger a restart loop.
- **Fix**: Replace `chmod -R a+w` with `chown -R agent:agent` — proper ownership with standard 755 permissions. Applied in both the Dockerfile (build time, after user creation) and entrypoint step 9 (runtime, in case doctor or npm recreates the directory).

## Changes

| File | What |
|------|------|
| `remote/Dockerfile` | Remove `chmod -R a+w` on acpx dir; add `chown -R agent:agent` after user creation |
| `remote/entrypoint.sh` | Add runtime `chown` for acpx dir in step 9 (Fix permissions) |

## Test plan

- [ ] Deploy to Fly.io and verify no acpx permission-related restarts in logs
- [ ] Confirm gateway starts cleanly and Telegram bot responds
- [ ] Verify `openclaw doctor` reports no acpx issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)