### PR TITLE
fix: stop unsetting OPENAI_API_KEY gateway-wide

### DIFF
--- a/remote/entrypoint.sh
+++ b/remote/entrypoint.sh
@@ -415,8 +415,8 @@ echo "Scheduling QMD embedding warm-up..."
 ) &
 
 # --- 14. Start gateway (foreground, PID 1) ---
-# Unset OPENAI_API_KEY so child processes (codex-acp adapter) use OAuth
-# instead of the API key. The gateway doesn't need it (uses OpenRouter via onboard).
-# OPENAI_API_KEY remains in .env.secrets for interactive SSH sessions.
+# OPENAI_API_KEY is kept in the gateway env for TTS/STT and OpenAI-dependent
+# services. The Codex wrapper (/usr/local/bin/codex) unsets it per-invocation
+# so Codex uses OAuth subscription auth instead.
 echo "=== Clawd Ready ==="
-exec su - agent -c 'source /data/.env.secrets && unset OPENAI_API_KEY && openclaw gateway run --port 18789 2>&1 | tee /data/logs/gateway.log'
+exec su - agent -c 'source /data/.env.secrets && openclaw gateway run --port 18789 2>&1 | tee /data/logs/gateway.log'


### PR DESCRIPTION
## Problem

Voice-to-text and TTS stopped working after PR #15 because `OPENAI_API_KEY` is unset before launching the gateway (entrypoint line 415).

## Root cause

The unset was added so Codex's ACP adapter would use OAuth subscription auth instead of the API key. But it also kills all OpenAI-dependent gateway services:
- TTS (`messages.tts.provider: "openai"`)
- STT / voice transcription
- Any future OpenAI model routing

## Fix

Remove the gateway-level `unset OPENAI_API_KEY`. The Codex wrapper at `/usr/local/bin/codex` (added in the Dockerfile) already handles this per-invocation:

```bash
#!/bin/bash
unset OPENAI_API_KEY
exec /usr/local/bin/codex-real "$@"
```

This is surgical — Codex gets its OAuth auth, everything else keeps the key.

Fixes #18