### PR TITLE
fix: seed audio transcription config for voice notes

### DIFF
--- a/remote/entrypoint.sh
+++ b/remote/entrypoint.sh
@@ -81,6 +81,8 @@ jq '
     .plugins.entries.acpx.enabled = true |
     .plugins.entries.acpx.config.permissionMode = "approve-all" |
     .tools.sessions.visibility = "agent" |
+    .tools.media.audio.enabled = true |
+    .tools.media.audio.models = [{"provider": "openai", "model": "gpt-4o-mini-transcribe", "capabilities": ["audio"]}] |
     .acp.enabled = true |
     .acp.backend = "acpx" |
     .acp.dispatch.enabled = true


### PR DESCRIPTION
## Problem

Voice note transcription didn't work on fresh deploys. The `tools.media.audio` config was never seeded in the entrypoint's jq patch — I had to add it manually via `config.patch` on the live VM.

## Root cause

The ACP integration (starting at `5df1b2b`) introduced several workarounds for Codex OAuth vs OpenAI API key conflicts. The `OPENAI_API_KEY` unset was fixed in `cded6c4`, but the media understanding pipeline also requires explicit config — it doesn't auto-detect just from having the key.

## What changed

Added to the infra-level jq patch in the entrypoint:

```json
.tools.media.audio.enabled = true |
.tools.media.audio.models = [{"provider": "openai", "model": "gpt-4o-mini-transcribe", "capabilities": ["audio"]}]
```

## Also verified (no changes needed)

- **QMD cache persistence** (`~/.cache → /data/.cache` symlink) — already handled correctly since the recent entrypoint updates
- **OPENAI_API_KEY availability** — fixed in `cded6c4`, confirmed the gateway process has the key
- **Session visibility** (`agent`) — already seeded in the jq patch

## Testing

Verified on live VM: manual API call to `gpt-4o-mini-transcribe` works, OpenClaw transcribes voice notes after gateway restart with this config.

Refs #18