### PR TITLE
fix: patch cron job models after state-repo restore and force-deploy

### DIFF
--- a/remote/entrypoint.sh
+++ b/remote/entrypoint.sh
@@ -127,6 +127,15 @@ _patch_agent_settings() {
 }
 if [ "${FORCE_AGENT_CONFIG:-}" = "1" ]; then
     _patch_agent_settings /data/.openclaw/openclaw.json
+    # Also patch cron job models when force-applying config
+    if [ -f /data/.openclaw/cron/jobs.json ]; then
+        CRON_MODEL="${CRON_MODEL:-$DEFAULT_CRON_MODEL}"
+        jq --arg model "$CRON_MODEL" '
+            .jobs |= map(
+                if (.payload.model // "" | test("^openrouter/")) then .payload.model = $model else . end
+            )
+        ' /data/.openclaw/cron/jobs.json > /tmp/cron-patch.tmp && mv /tmp/cron-patch.tmp /data/.openclaw/cron/jobs.json
+    fi
 fi
 
 # --- 5. Inject Telegram allowlist + group access ---
@@ -293,6 +302,15 @@ if [ "$_state_restored" -eq 1 ]; then
         /data/.openclaw/openclaw.json > /data/.openclaw/openclaw.json.tmp \
         && mv /data/.openclaw/openclaw.json.tmp /data/.openclaw/openclaw.json
     _patch_agent_settings /data/.openclaw/openclaw.json
+    # Patch cron job models to match current credentials (state-repo may have stale provider prefixes)
+    if [ -f /data/.openclaw/cron/jobs.json ]; then
+        echo "Patching cron job models after state restore..."
+        jq --arg model "$DEFAULT_CRON_MODEL" '
+            .jobs |= map(
+                if (.payload.model // "" | test("^openrouter/")) then .payload.model = $model else . end
+            )
+        ' /data/.openclaw/cron/jobs.json > /tmp/cron-patch.tmp && mv /tmp/cron-patch.tmp /data/.openclaw/cron/jobs.json
+    fi
 fi
 
 # --- 9. Fix permissions ---


### PR DESCRIPTION
Two fixes for state management after provider/config changes:

## 1. Patch cron job models after state-repo restore and force-deploy

After restoring from the state repo or running `FORCE_AGENT_CONFIG=1`, cron jobs could retain stale `openrouter/` model prefixes from before a provider switch.

**Root cause:** The entrypoint re-applies `_patch_agent_settings` (which fixes `openclaw.json` primary model) after restore, but never touched cron job models. The cron seed logic only runs on first boot when no `jobs.json` exists.

**Fix:** After state-repo restore and in the `FORCE_AGENT_CONFIG` path, run a jq patch that rewrites any `openrouter/`-prefixed cron model to `$DEFAULT_CRON_MODEL`.

## 2. Fix background state-sync loop: STATE_REPO not available

The background state-sync loop (`/usr/local/bin/state-sync.sh`) has been silently failing every 30 minutes with `STATE_REPO not set`.

**Root cause:** `STATE_REPO` and `STATE_SYNC_INTERVAL` were excluded from `.env.secrets` in the env-forwarding logic. The background loop runs via `su - agent -c 'source /data/.env.secrets && ...'`, so these vars were never available.

**Fix:** Remove `STATE_REPO` and `STATE_SYNC_INTERVAL` from the exclusion list. They aren't sensitive (repo URL + interval number) and are needed at runtime.