### PR TITLE
feat: add config validation + streaming/echo config changes

### DIFF
--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -12,14 +12,21 @@
       "enabled": true,
       "dmPolicy": "allowlist",
       "allowFrom": [],
-      "streaming": "off"
+      "streaming": "partial"
     },
     "slack": {
       "enabled": true,
       "mode": "socket",
       "groupPolicy": "open",
-      "streaming": "off",
+      "streaming": "partial",
       "nativeStreaming": false
+    }
+  },
+  "tools": {
+    "media": {
+      "audio": {
+        "echoTranscript": true
+      }
     }
   },
   "plugins": {

--- a/remote/entrypoint.sh
+++ b/remote/entrypoint.sh
@@ -344,6 +344,12 @@ echo "Enabling hooks..."
 su - agent -c 'source /data/.env.secrets && openclaw hooks enable session-memory' 2>&1 || true
 su - agent -c 'source /data/.env.secrets && openclaw hooks enable boot-md' 2>&1 || true
 
+# --- 11.5. Validate config ---
+echo "Validating OpenClaw config..."
+if command -v openclaw >/dev/null 2>&1; then
+    openclaw config validate 2>&1 || echo "! Config validation warning (non-fatal on older versions)"
+fi
+
 # --- 12. Onboard API credentials ---
 echo "Registering API credentials..."
 # Primary: Anthropic subscription (setup-token) > Anthropic API key


### PR DESCRIPTION
## Summary
- set seed streaming mode to `partial` for Telegram and Slack in `config/openclaw.json`
- add seed `tools.media.audio.echoTranscript: true` in `config/openclaw.json`
- add non-fatal OpenClaw config validation step in `remote/entrypoint.sh` before gateway startup

## Testing
- not run (config + shell entrypoint edits only)

Closes #26