### PR TITLE
fix: bust Docker cache for npm install layers on every deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,6 @@ jobs:
           FLY_APP_NAME: ${{ vars.FLY_APP_NAME }}
 
       - name: Deploy to Fly.io
-        run: flyctl deploy --remote-only
+        run: flyctl deploy --remote-only --build-arg CACHEBUST=${{ github.sha }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/remote/Dockerfile
+++ b/remote/Dockerfile
@@ -64,6 +64,10 @@ RUN curl -fsSL https://bun.sh/install | bash \
 
 # OpenClaw + QMD memory backend
 # chmod: node-llama-cpp needs write access for CPU backend build at runtime (runs as agent user)
+# CACHEBUST forces Docker to re-run npm install when a new version is desired.
+# Set via: flyctl deploy --build-arg CACHEBUST=$(date +%s)
+# Or in CI: --build-arg CACHEBUST=${{ github.sha }}
+ARG CACHEBUST=1
 RUN npm install -g openclaw@latest @tobilu/qmd@latest \
     && chmod -R a+w /usr/lib/node_modules/@tobilu/qmd/node_modules/node-llama-cpp/
 


### PR DESCRIPTION
## Problem

OpenClaw binary wasn't updating on deploy (`2026.2.26` → should be `2026.3.2`). Docker cached the `npm install -g openclaw@latest` layer since no preceding layers changed, so `@latest` resolved to the cached version.

Live update via `sudo npm install` also failed (SIGTERM after 27 min on shared CPUs — too resource-intensive while gateway is running).

## Fix

- Add `ARG CACHEBUST=1` before the npm install layers in the Dockerfile
- Pass `--build-arg CACHEBUST=${{ github.sha }}` in CI deploy step
- Every merge to main gets a unique CACHEBUST value → Docker re-runs npm install

For manual deploys: `flyctl deploy --build-arg CACHEBUST=$(date +%s)`

## Trade-off

This means every deploy reinstalls all global npm packages (~60s extra build time). Worth it to ensure we always get latest versions. If build times become a concern, we could pin specific versions and only bust cache on version bumps.