### PR TITLE
feat: run conversation extraction before state sync

### DIFF
--- a/remote/state-sync.sh
+++ b/remote/state-sync.sh
@@ -46,6 +46,12 @@ for dir in workspace/*/; do
     fi
 done
 
+# Extract conversation digests (if script exists) before staging
+EXTRACT_SCRIPT="$OPENCLAW_DIR/workspace/scripts/extract-conversations.py"
+if [ -f "$EXTRACT_SCRIPT" ] && command -v python3 >/dev/null 2>&1; then
+    python3 "$EXTRACT_SCRIPT" "$OPENCLAW_DIR" 2>/dev/null || true
+fi
+
 # Stage and commit
 git add -A
 


### PR DESCRIPTION
Runs `extract-conversations.py` before each state sync commit (every 30 min via background loop). Keeps QMD conversation digests fresh without a separate cron job.

Gracefully skips if the script or python3 isn't available.