### PR TITLE
fix: disable compaction memoryFlush to prevent death spiral

### DIFF
--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -93,8 +93,7 @@
         "mode": "default",
         "reserveTokensFloor": 30000,
         "memoryFlush": {
-          "enabled": true,
-          "softThresholdTokens": 4000
+          "enabled": false
         }
       },
       "contextPruning": {


### PR DESCRIPTION
## Problem

`memoryFlush` injects a "Pre-compaction memory flush" user message before each compaction, asking the model to persist memories to disk. Each flush triggers a full model turn with tool calls (memory writes), generating thousands of uncached tokens that grow context and trigger further compactions.

**Observed:** 11 compactions in ~6 hours with minimal user activity on session `65a67e34`.

**Timeline:**
- 19:07 UTC — 152k/200k context, 0 compactions
- 21:16 UTC — first flush/compaction cycle begins  
- 22:22 UTC — 9 compactions
- 01:29 UTC — 11 compactions

**Root cause:** flush → model turn → context growth → compaction → flush (death spiral)

## Fix

Disable `memoryFlush.enabled`. Context persistence is already covered by:
- QMD memory backend (semantic search over MEMORY.md + journals)
- `working-context-snapshot` cron (every 30 min)
- Conversation digest extraction (state-sync pipeline)
- `session-memory` hook (fires on session reset)

## Changes

- `config/openclaw.json`: set `memoryFlush.enabled: false`, remove `softThresholdTokens`