### PR TITLE
feat(config): add model fallbacks and reduce health check frequency

### DIFF
--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -87,6 +87,24 @@
           "alias": "Codex"
         }
       },
+      "memorySearch": {
+        "extraPaths": ["journal", "patterns", "docs"],
+        "query": {
+          "hybrid": {
+            "enabled": true,
+            "vectorWeight": 0.7,
+            "textWeight": 0.3,
+            "mmr": {
+              "enabled": true,
+              "lambda": 0.7
+            },
+            "temporalDecay": {
+              "enabled": true,
+              "halfLifeDays": 30
+            }
+          }
+        }
+      },
       "sandbox": {
         "mode": "off"
       },
@@ -159,16 +177,18 @@
     "backend": "qmd",
     "citations": "auto",
     "qmd": {
+      "command": "qmd",
       "includeDefaultMemory": true,
       "update": {
         "interval": "5m",
         "debounceMs": 15000,
+        "onBoot": true,
         "waitForBootSync": false
       },
       "limits": {
-        "maxResults": 6,
+        "maxResults": 8,
         "maxSnippetChars": 2000,
-        "timeoutMs": 4000
+        "timeoutMs": 5000
       },
       "paths": [
         {


### PR DESCRIPTION
## Changes

### Model fallback chain
Adds cross-provider fallback: **Opus → GPT-5.2 → Sonnet**

When Anthropic API returns 529 (overloaded), the agent now degrades to OpenAI GPT-5.2, then Sonnet — instead of failing silently with no response to the user.

OpenAI provides real provider diversity (different infrastructure). Sonnet is kept as a last resort since Anthropic overloads may affect both Opus and Sonnet.

### Channel health check interval
Increases `channelHealthCheckMinutes` from **30** (default) → **120**.

The default 30-minute interval was causing ~23 Telegram/Slack socket restarts per day. Each restart creates a brief reconnection window where inbound messages could be dropped. 120 minutes is conservative enough to still catch genuinely stale sockets.

## Context

Diagnosed from production logs on the Tars VM:
- Anthropic 529 errors caused silent agent run failures (no user notification)
- Health monitor was cycling both Telegram and Slack sockets every ~30 min
- Both issues contributed to a pattern where messages appeared to be "swallowed"

## Notes

- OpenClaw doesn't currently have a config option to notify users when agent runs fail — fallbacks are the best mitigation available
- The `OPENAI_API_KEY` env var is used for the GPT-5.2 fallback (separate from Codex CLI's ChatGPT OAuth auth)