### PR TITLE
fix: ensure ACP sub-agents can push to GitHub

### DIFF
--- a/remote/entrypoint.sh
+++ b/remote/entrypoint.sh
@@ -473,6 +473,12 @@ ln -sfn /data/.ssh /home/agent/.ssh
 ln -sfn /data/git/config /home/agent/.gitconfig
 ln -sfn /data/.gnupg /home/agent/.gnupg
 
+# Ensure HTTPS → SSH rewrite for GitHub so ACP sub-agents (Codex, etc.)
+# can push without needing GH_TOKEN in their environment.
+if [ -s /data/.ssh/id_ed25519 ]; then
+    su - agent -c 'git config --global url."git@github.com:".insteadOf "https://github.com/"' 2>/dev/null || true
+fi
+
 # --- 8. Restore from state repo (fresh volume only) ---
 # If STATE_REPO is set and no MEMORY.md exists, this is likely a fresh volume.
 # Clone the state repo directly into /data/.openclaw — the same dir used for

--- a/remote/entrypoint.sh
+++ b/remote/entrypoint.sh
@@ -473,12 +473,6 @@ ln -sfn /data/.ssh /home/agent/.ssh
 ln -sfn /data/git/config /home/agent/.gitconfig
 ln -sfn /data/.gnupg /home/agent/.gnupg
 
-# Ensure HTTPS → SSH rewrite for GitHub so ACP sub-agents (Codex, etc.)
-# can push without needing GH_TOKEN in their environment.
-if [ -s /data/.ssh/id_ed25519 ]; then
-    su - agent -c 'git config --global url."git@github.com:".insteadOf "https://github.com/"' 2>/dev/null || true
-fi
-
 # --- 8. Restore from state repo (fresh volume only) ---
 # If STATE_REPO is set and no MEMORY.md exists, this is likely a fresh volume.
 # Clone the state repo directly into /data/.openclaw — the same dir used for
@@ -521,6 +515,13 @@ chown -R agent:agent /data/.openclaw /data/.claude /data/.codex /data/.cache /da
 # acpx plugin dirs must be owned by agent — OpenClaw blocks world-writable extensions
 chown -R agent:agent /usr/lib/node_modules/openclaw/extensions/acpx/ 2>/dev/null || true
 chown -R agent:agent /usr/lib/node_modules/openclaw/dist/extensions/acpx/ 2>/dev/null || true
+
+# Ensure GitHub SSH trust + HTTPS → SSH rewrite after ownership is fixed so
+# agent-scoped git config writes succeed on fresh volumes.
+if [ -s /data/.ssh/id_ed25519 ]; then
+    su - agent -c 'mkdir -p ~/.ssh && touch ~/.ssh/known_hosts && chmod 600 ~/.ssh/known_hosts && ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null' || true
+    su - agent -c 'git config --global url."git@github.com:".insteadOf "https://github.com/"' 2>/dev/null || true
+fi
 
 # --- 10. Tailscale (optional) ---
 if [ -n "${TAILSCALE_AUTHKEY:-}" ]; then

--- a/remote/vm-setup.sh
+++ b/remote/vm-setup.sh
@@ -144,6 +144,25 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 4b. Git HTTPS → SSH rewrite
+# ---------------------------------------------------------------------------
+# ACP sub-agents (Codex, Claude Code) run in sandboxed subprocesses that may
+# not inherit GH_TOKEN, causing `gh auth git-credential` to fail on HTTPS
+# pushes. Rewriting HTTPS → SSH ensures git operations work for any subprocess
+# as long as the SSH key is present — no token forwarding required.
+CURRENT_INSTEAD_OF=$(git config --global url."git@github.com:".insteadOf 2>/dev/null || true)
+if [ "$CURRENT_INSTEAD_OF" = "https://github.com/" ]; then
+    ok "HTTPS → SSH rewrite already configured"
+else
+    if [ -f "$SSH_KEY" ]; then
+        git config --global url."git@github.com:".insteadOf "https://github.com/"
+        ok "Configured HTTPS → SSH rewrite for github.com"
+    else
+        warn "No SSH key — skipping HTTPS → SSH rewrite"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
 # 5. SSH config for GitHub
 # ---------------------------------------------------------------------------
 header "SSH Config"

--- a/remote/vm-setup.sh
+++ b/remote/vm-setup.sh
@@ -168,6 +168,7 @@ fi
 header "SSH Config"
 
 SSH_CONFIG="$HOME/.ssh/config"
+KNOWN_HOSTS="$HOME/.ssh/known_hosts"
 
 if grep -q 'Host github.com' "$SSH_CONFIG" 2>/dev/null; then
     ok "GitHub SSH config already exists"
@@ -185,6 +186,18 @@ SSHEOF
         ok "Added github.com entry to ~/.ssh/config"
     else
         warn "No SSH key — skipping SSH config"
+    fi
+fi
+
+if [ -f "$SSH_KEY" ]; then
+    mkdir -p "$(dirname "$KNOWN_HOSTS")"
+    touch "$KNOWN_HOSTS"
+    chmod 600 "$KNOWN_HOSTS"
+    if ssh-keygen -F github.com -f "$KNOWN_HOSTS" >/dev/null 2>&1; then
+        ok "GitHub host key already present in known_hosts"
+    else
+        ssh-keyscan github.com >> "$KNOWN_HOSTS" 2>/dev/null
+        ok "Added github.com host key to known_hosts"
     fi
 fi
 

--- a/scripts/sandbox-up.sh
+++ b/scripts/sandbox-up.sh
@@ -44,6 +44,8 @@ OC_ENV=(
 [ -n "${ANTHROPIC_API_KEY:-}" ]      && OC_ENV+=(-e "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}")
 [ -n "${OPENROUTER_API_KEY:-}" ]     && OC_ENV+=(-e "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}")
 [ -n "${OPENAI_API_KEY:-}" ]         && OC_ENV+=(-e "OPENAI_API_KEY=${OPENAI_API_KEY}")
+[ -n "${GH_TOKEN:-}" ]              && OC_ENV+=(-e "GH_TOKEN=${GH_TOKEN}")
+[ -n "${GITHUB_TOKEN:-}" ]          && OC_ENV+=(-e "GITHUB_TOKEN=${GITHUB_TOKEN}")
 
 # Check if sandbox already exists
 if docker sandbox ls 2>/dev/null | grep -q "$SANDBOX_NAME"; then


### PR DESCRIPTION
## Problem

Codex (and other ACP sub-agents) fail on `git push` because:
- They run in sandboxed subprocesses that don't inherit `GH_TOKEN`
- `gh auth git-credential` (the configured HTTPS credential helper) fails without the token
- HTTPS git operations silently fail with auth errors

## Fix (belt and suspenders)

### 1. Pass `GH_TOKEN`/`GITHUB_TOKEN` into sandbox (`sandbox-up.sh`)
```bash
[ -n "${GH_TOKEN:-}" ]     && OC_ENV+=(-e "GH_TOKEN=${GH_TOKEN}")
[ -n "${GITHUB_TOKEN:-}" ] && OC_ENV+=(-e "GITHUB_TOKEN=${GITHUB_TOKEN}")
```

### 2. HTTPS → SSH rewrite (`entrypoint.sh` + `vm-setup.sh`)
```bash
git config --global url."git@github.com:".insteadOf "https://github.com/"
```
Applied on every boot when an SSH key exists. Any subprocess that clones/pushes via HTTPS gets silently rewritten to use SSH — no token forwarding needed.

### 3. Interactive setup (`vm-setup.sh`)
Same `insteadOf` rule added to the interactive setup flow with explanation.

## Testing
Verified on the live VM:
- `env -u GH_TOKEN git push` succeeds via SSH after the `insteadOf` rule
- Codex-created branch (`feat/polymarket-signal-analysis` on `recallnet/hype-funding-arb`) pushed successfully after switching remote to SSH