### PR TITLE
chore(config): relax context/session retention for long-running threads

### DIFF
--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -97,8 +97,8 @@
       },
       "contextPruning": {
         "mode": "cache-ttl",
-        "ttl": "5m",
-        "keepLastAssistants": 3,
+        "ttl": "36h",
+        "keepLastAssistants": 8,
         "tools": {
           "allow": ["exec", "read", "web_fetch", "browser", "process"],
           "deny": ["memory_search", "memory_get"]
@@ -109,7 +109,7 @@
           "tailChars": 1500
         },
         "hardClear": {
-          "enabled": true,
+          "enabled": false,
           "placeholder": "[Old tool result cleared]"
         }
       },
@@ -169,9 +169,17 @@
   "session": {
     "reset": {
       "mode": "idle",
-      "idleMinutes": 180
+      "idleMinutes": 43200
     },
     "resetByType": {
+      "direct": {
+        "mode": "idle",
+        "idleMinutes": 43200
+      },
+      "dm": {
+        "mode": "idle",
+        "idleMinutes": 43200
+      },
       "group": {
         "mode": "daily",
         "atHour": 9
@@ -183,7 +191,7 @@
     },
     "maintenance": {
       "mode": "enforce",
-      "pruneAfter": "30d",
+      "pruneAfter": "365d",
       "maxEntries": 500,
       "maxDiskBytes": "2gb"
     }


### PR DESCRIPTION
## Summary\n- increase context pruning TTL from 5m to 36h\n- keep more assistant turns in context (3 -> 8)\n- disable hard clear of old tool results\n- extend session idle reset window to 30 days (global + direct/dm overrides)\n- extend session maintenance prune window to 365 days\n\n## Why\nDM conversations were resetting/pruning too aggressively for week+ continuity. This keeps long-running threads restorable while preserving explicit maintenance limits.