### PR TITLE
chore(sync): default state backup loop to daily

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,14 +79,14 @@ If `STATE_REPO` is set (as a Fly secret), the remote VM automatically syncs live
 **How it works:**
 
 - On fresh volumes (no `MEMORY.md` found), entrypoint restores state from the repo — workspace, config, cron jobs, and agent data
-- A background loop runs `state-sync.sh` every 30 minutes, pushing changes back to the repo
+- A background loop runs `state-sync.sh` once per day by default, pushing changes back to the repo
 - The persistent clone lives at `/data/state-repo` (shared between restore and sync)
 - Only commits when changes are detected; commit messages include a UTC timestamp
 
 **Env vars (Fly secrets):**
 
 - `STATE_REPO` — SSH URL of the state git repo (e.g. `git@github.com:user/clawd-state.git`). Required to enable sync.
-- `STATE_SYNC_INTERVAL` — Seconds between syncs (default: `1800` / 30 minutes)
+- `STATE_SYNC_INTERVAL` — Seconds between syncs (default: `86400` / 24 hours)
 
 **Prerequisites:** SSH key and git identity must be configured on the VM via `vm-setup.sh` for push access.
 

--- a/README.md
+++ b/README.md
@@ -130,10 +130,10 @@ make deploy
 
 **How it works:**
 
-- A background sync loop pushes state to the repo every 30 minutes (no API credits — pure shell)
+- A background sync loop pushes state to the repo once per day by default (no API credits — pure shell)
 - On fresh volume deployments, the entrypoint detects no existing state and restores from the repo
 - Existing volumes are never affected — restore only triggers when `MEMORY.md` is absent
-- Set `STATE_SYNC_INTERVAL` (seconds) to change the sync frequency (default: `1800`)
+- Set `STATE_SYNC_INTERVAL` (seconds) to change the sync frequency (default: `86400`)
 
 **Repo structure:**
 

--- a/remote/entrypoint.sh
+++ b/remote/entrypoint.sh
@@ -625,7 +625,7 @@ done
 # Commits and pushes /data/.openclaw directly (no separate clone).
 # STATE_REPO and STATE_SYNC_INTERVAL are available via .env.secrets.
 if [ -n "${STATE_REPO:-}" ]; then
-    SYNC_INTERVAL="${STATE_SYNC_INTERVAL:-1800}"
+    SYNC_INTERVAL="${STATE_SYNC_INTERVAL:-86400}"
     echo "Starting state sync loop (interval: ${SYNC_INTERVAL}s)..."
     (
         while sleep "$SYNC_INTERVAL"; do


### PR DESCRIPTION
## Summary
- change background state-sync loop default interval from 1800s (30m) to 86400s (24h)
- update README + CLAUDE docs to match the new default

## Why
Recent backup commits were too noisy. Daily default keeps protection while reducing commit churn.

## Notes
- STATE_SYNC_INTERVAL still overrides this behavior when explicitly set.
