### PR TITLE
chore(cron): run working-context snapshot daily

### DIFF
--- a/config/cron/jobs.json
+++ b/config/cron/jobs.json
@@ -129,9 +129,8 @@
       "id": "c355607a-01af-4737-b69e-032710997a46",
       "name": "working-context-snapshot",
       "schedule": {
-        "kind": "every",
-        "everyMs": 1800000,
-        "anchorMs": 1772933443519
+        "kind": "cron",
+        "expr": "0 7 * * *"
       },
       "enabled": true,
       "payload": {


### PR DESCRIPTION
## Summary
- change working-context-snapshot schedule from interval-based execution to daily cron
- set cron expression to 0 7 * * *