### PR TITLE
chore(config): remove direct OpenAI API-key fallbacks for inference

### DIFF
--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -37,8 +37,6 @@
       "model": {
         "primary": "anthropic/claude-opus-4-6",
         "fallbacks": [
-          "openai/gpt-5.3-codex",
-          "openai/gpt-5.2-codex",
           "openrouter/openai/gpt-5.2-codex",
           "anthropic/claude-sonnet-4-5"
         ]


### PR DESCRIPTION
Inference should not use OPENAI_API_KEY; keep OpenAI key for audio tooling only.