### PR TITLE
Update OpenAI model defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,7 @@ TELEGRAM_BOT_TOKEN=123456:ABC-DEF...
 # OPENCLAW_GATEWAY_TOKEN=
 
 # Optional cron model overrides
-# CRON_MODEL=openai-codex/gpt-5.4
+# CRON_MODEL=openai-codex/gpt-5.3-codex
 # CRON_LIGHT_MODEL=openai-codex/gpt-5.3-codex-spark
 
 # Telegram user IDs allowed to message the bot (comma-separated)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Secrets live in `.env` (gitignored). They are passed to the sandbox via environm
 
 Codex OAuth is the primary provider. Anthropic and OpenRouter are fallback model providers. Set credentials as follows:
 
-- **Primary: ChatGPT/Codex subscription OAuth** — run `make fly-auth`, then on the VM run `codex login --device-auth` and `openclaw onboard --auth-choice openai-codex`. OpenClaw then uses `openai-codex/gpt-5.5` as the main gateway model with `openai-codex/gpt-5.4` as the same-provider fallback, backed by `/data/.codex/auth.json`.
+- **Primary: ChatGPT/Codex subscription OAuth** — run `make fly-auth`, then on the VM run `codex login --device-auth` and `openclaw onboard --auth-choice openai-codex`. OpenClaw then uses `openai-codex/gpt-5.4` as the main gateway model with `openai-codex/gpt-5.3-codex` as the same-provider fallback, backed by `/data/.codex/auth.json`.
 - **Anthropic fallback**: `ANTHROPIC_API_KEY=sk-ant-...` or Claude CLI auth (`claude auth login` then `openclaw models auth login --provider anthropic --method cli`). Model IDs use `anthropic/` or `claude-cli/`.
 - **OpenRouter fallback**: `OPENROUTER_API_KEY=sk-or-...` — used as the final backup and for models not available through native providers. Model IDs use the `openrouter/` prefix.
 - **OpenAI API key**: `OPENAI_API_KEY=sk-...` — used only for voice features such as TTS/STT/transcription. It is not used for gateway model routing or Codex auth.
@@ -187,7 +187,7 @@ Fresh deployments are seeded with 5 default cron jobs. These run inside the Open
 
 **Config:** `config/cron/jobs.json` — uses OpenClaw's native format (`{"version":1,"jobs":[...]}`). Each job has a pre-generated UUID that the gateway preserves.
 
-**Model override:** Jobs default to `openai-codex/gpt-5.5`. Set `CRON_MODEL` as a Fly secret to override the standard cron lane (for example `CRON_MODEL=anthropic/claude-opus-4-6`). Set `CRON_LIGHT_MODEL` to override the lightweight cron lane, which currently applies to `working-context-snapshot` only (for example `CRON_LIGHT_MODEL=openai-codex/gpt-5.3-codex-spark`). If `CRON_LIGHT_MODEL` is unset, it falls back to `CRON_MODEL`. This keeps the hierarchy explicit without making Spark a hard requirement. If Codex OAuth is unavailable, the entrypoint falls back to Claude CLI, then Anthropic API, then OpenRouter (unless `CRON_MODEL` is explicitly set). The entrypoint substitutes these at seed time via `jq`.
+**Model override:** Jobs default to `openai-codex/gpt-5.3-codex`. Set `CRON_MODEL` as a Fly secret to override the standard cron lane (for example `CRON_MODEL=anthropic/claude-opus-4-6`). Set `CRON_LIGHT_MODEL` to override the lightweight cron lane, which currently applies to `working-context-snapshot` only (for example `CRON_LIGHT_MODEL=openai-codex/gpt-5.3-codex-spark`). If `CRON_LIGHT_MODEL` is unset, it falls back to `CRON_MODEL`. This keeps the hierarchy explicit without making Spark a hard requirement. If Codex OAuth is unavailable, the entrypoint falls back to Claude CLI, then Anthropic API, then OpenRouter (unless `CRON_MODEL` is explicitly set). The entrypoint substitutes these at seed time via `jq`.
 
 **Seeding behavior:**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Secrets live in `.env` (gitignored). They are passed to the sandbox via environm
 
 Codex OAuth is the primary provider. Anthropic and OpenRouter are fallback model providers. Set credentials as follows:
 
-- **Primary: ChatGPT/Codex subscription OAuth** — run `make fly-auth`, then on the VM run `codex login --device-auth` and `openclaw onboard --auth-choice openai-codex`. OpenClaw then uses `openai-codex/gpt-5.4` as the main gateway model, backed by `/data/.codex/auth.json`.
+- **Primary: ChatGPT/Codex subscription OAuth** — run `make fly-auth`, then on the VM run `codex login --device-auth` and `openclaw onboard --auth-choice openai-codex`. OpenClaw then uses `openai-codex/gpt-5.5` as the main gateway model with `openai-codex/gpt-5.4` as the same-provider fallback, backed by `/data/.codex/auth.json`.
 - **Anthropic fallback**: `ANTHROPIC_API_KEY=sk-ant-...` or Claude CLI auth (`claude auth login` then `openclaw models auth login --provider anthropic --method cli`). Model IDs use `anthropic/` or `claude-cli/`.
 - **OpenRouter fallback**: `OPENROUTER_API_KEY=sk-or-...` — used as the final backup and for models not available through native providers. Model IDs use the `openrouter/` prefix.
 - **OpenAI API key**: `OPENAI_API_KEY=sk-...` — used only for voice features such as TTS/STT/transcription. It is not used for gateway model routing or Codex auth.
@@ -187,7 +187,7 @@ Fresh deployments are seeded with 5 default cron jobs. These run inside the Open
 
 **Config:** `config/cron/jobs.json` — uses OpenClaw's native format (`{"version":1,"jobs":[...]}`). Each job has a pre-generated UUID that the gateway preserves.
 
-**Model override:** Jobs default to `openai-codex/gpt-5.4`. Set `CRON_MODEL` as a Fly secret to override the standard cron lane (for example `CRON_MODEL=anthropic/claude-opus-4-6`). Set `CRON_LIGHT_MODEL` to override the lightweight cron lane, which currently applies to `working-context-snapshot` only (for example `CRON_LIGHT_MODEL=openai-codex/gpt-5.3-codex-spark`). If `CRON_LIGHT_MODEL` is unset, it falls back to `CRON_MODEL`. This keeps the hierarchy explicit without making Spark a hard requirement. If Codex OAuth is unavailable, the entrypoint falls back to Claude CLI, then Anthropic API, then OpenRouter (unless `CRON_MODEL` is explicitly set). The entrypoint substitutes these at seed time via `jq`.
+**Model override:** Jobs default to `openai-codex/gpt-5.5`. Set `CRON_MODEL` as a Fly secret to override the standard cron lane (for example `CRON_MODEL=anthropic/claude-opus-4-6`). Set `CRON_LIGHT_MODEL` to override the lightweight cron lane, which currently applies to `working-context-snapshot` only (for example `CRON_LIGHT_MODEL=openai-codex/gpt-5.3-codex-spark`). If `CRON_LIGHT_MODEL` is unset, it falls back to `CRON_MODEL`. This keeps the hierarchy explicit without making Spark a hard requirement. If Codex OAuth is unavailable, the entrypoint falls back to Claude CLI, then Anthropic API, then OpenRouter (unless `CRON_MODEL` is explicitly set). The entrypoint substitutes these at seed time via `jq`.
 
 **Seeding behavior:**
 

--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ agent-state/
 ### Model
 
 Set in `config/openclaw.json` at `agents.defaults.model.primary`. The repo now defaults to
-`openai-codex/gpt-5.4`, which uses ChatGPT/Codex OAuth through OpenClaw's native `openai-codex`
-provider. Anthropic API models use `anthropic/`, Claude CLI models use `claude-cli/`, and
+`openai-codex/gpt-5.5`, with `openai-codex/gpt-5.4` as the same-provider fallback.
+It uses ChatGPT/Codex OAuth through OpenClaw's native `openai-codex` provider. Anthropic API models use `anthropic/`, Claude CLI models use `claude-cli/`, and
 OpenRouter models use `openrouter/`. This repo does not use `OPENAI_API_KEY` for model routing.
 Run `make reset`
 (local) or `make deploy` (remote) to apply.
@@ -184,7 +184,7 @@ Example:
 
 ```bash
 fly secrets set \
-  CRON_MODEL='openai-codex/gpt-5.4' \
+  CRON_MODEL='openai-codex/gpt-5.5' \
   CRON_LIGHT_MODEL='openai-codex/gpt-5.3-codex-spark' \
   -a my-clawd
 make deploy-cron-upsert

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ agent-state/
 ### Model
 
 Set in `config/openclaw.json` at `agents.defaults.model.primary`. The repo now defaults to
-`openai-codex/gpt-5.5`, with `openai-codex/gpt-5.4` as the same-provider fallback.
+`openai-codex/gpt-5.4`, with `openai-codex/gpt-5.3-codex` as the same-provider fallback.
 It uses ChatGPT/Codex OAuth through OpenClaw's native `openai-codex` provider. Anthropic API models use `anthropic/`, Claude CLI models use `claude-cli/`, and
 OpenRouter models use `openrouter/`. This repo does not use `OPENAI_API_KEY` for model routing.
 Run `make reset`
@@ -184,7 +184,7 @@ Example:
 
 ```bash
 fly secrets set \
-  CRON_MODEL='openai-codex/gpt-5.5' \
+  CRON_MODEL='openai-codex/gpt-5.3-codex' \
   CRON_LIGHT_MODEL='openai-codex/gpt-5.3-codex-spark' \
   -a my-clawd
 make deploy-cron-upsert

--- a/config/cron/jobs.json
+++ b/config/cron/jobs.json
@@ -12,7 +12,7 @@
       "payload": {
         "kind": "agentTurn",
         "message": "Run the security audit script: bash /data/.openclaw/workspace/scripts/security-audit.sh\n\nIf exit code is 0, reply with just: \"Security audit clean.\"\nIf exit code is non-zero, report each finding with severity and a suggested fix.",
-        "model": "openai-codex/gpt-5.4",
+        "model": "openai-codex/gpt-5.3-codex",
         "timeoutSeconds": 120
       },
       "wakeMode": "next-heartbeat",
@@ -43,7 +43,7 @@
       "payload": {
         "kind": "agentTurn",
         "message": "Run the state sync script: bash /data/.openclaw/workspace/scripts/state-sync.sh\n\nIf it succeeds, reply with just: \"State sync complete.\"\nIf it fails, report the error and suggest recovery steps.",
-        "model": "openai-codex/gpt-5.4",
+        "model": "openai-codex/gpt-5.3-codex",
         "timeoutSeconds": 120
       },
       "wakeMode": "next-heartbeat",
@@ -74,7 +74,7 @@
       "payload": {
         "kind": "agentTurn",
         "message": "Review recent memory files in memory/ for the last 24 hours. If anything notable happened (new learnings, resolved issues, configuration changes, user preferences discovered), consolidate into a brief update in the appropriate memory file. If nothing notable, reply ANNOUNCE_SKIP.",
-        "model": "openai-codex/gpt-5.4",
+        "model": "openai-codex/gpt-5.3-codex",
         "timeoutSeconds": 120
       },
       "wakeMode": "next-heartbeat",
@@ -105,7 +105,7 @@
       "payload": {
         "kind": "agentTurn",
         "message": "Perform a weekly memory rollup:\n\n1. Read MEMORY.md\n2. Check if any facts are stale (e.g., config values that may have changed, resolved issues still listed, old project references)\n3. Read memory/*.md files for the past week\n4. Consolidate: merge redundant entries, promote recurring patterns to Key Decisions if durable, remove one-off entries\n5. Update MEMORY.md with the cleaned version\n6. Keep MEMORY.md under 80 lines — it should be scannable, not exhaustive\n7. Do NOT add project-specific status or task lists — those belong in working-context files\n\nReply with a brief summary of what changed.",
-        "model": "openai-codex/gpt-5.4",
+        "model": "openai-codex/gpt-5.3-codex",
         "timeoutSeconds": 180
       },
       "wakeMode": "next-heartbeat",
@@ -135,7 +135,7 @@
       "enabled": true,
       "payload": {
         "kind": "agentTurn",
-        "model": "openai-codex/gpt-5.4",
+        "model": "openai-codex/gpt-5.3-codex",
         "timeoutSeconds": 90,
         "message": "You are a working-context snapshot agent. Your job is to persist context per session so one thread cannot overwrite another.\n\nSteps:\n\n1. Call sessions_list(activeMinutes=65) to find sessions with recent activity.\n2. Filter out sessions that are only cron runs (sessionKey starting with 'cron:') or have no meaningful user messages.\n3. If NO sessions have meaningful recent activity, reply ANNOUNCE_SKIP. Do NOT touch or delete existing working-context files.\n4. For each remaining session, call sessions_history(sessionKey=<key>, limit=20) and build a concise snapshot.\n5. For each session:\n   - Compute canonical safeSessionKey by replacing every character not in [A-Za-z0-9._] with '_'.\n   - Read the EXISTING working-context file (if any) to preserve the Work Log section.\n   - Write canonical file: memory/working-context-<safeSessionKey>.md\n   - If safeSessionKey starts with agent_main_, ALSO write legacy alias file with that prefix removed:\n     memory/working-context-<safeSessionKeyWithoutAgentMainPrefix>.md\n   - Both files must have identical content.\n\nUse this format:\n\n# Working Context\n_Snapshot: <current UTC timestamp>_\n_Session: <original sessionKey>_\n\n## Active Task\n<What's being worked on — 1-2 sentences>\n\n## Current Status\n<Bullets>\n\n## Next Steps\n<Bullets>\n\n## Key Details\n<Specific values, error messages, file paths, branch names, decisions>\n\n## Work Log\n<Rolling log of completed work items — append-only, most recent first. Carry forward ALL existing entries from the previous snapshot's Work Log section. Add new entries for any completed work visible in the current session history. Each entry: `- [YYYY-MM-DD HH:MM] <brief description of what was done>`. Keep max 20 entries; drop oldest if over limit.>\n\nKeep Active Task / Status / Next Steps / Key Details under 20 lines total. Work Log can be up to 20 additional lines.\n\n6. If snapshots were written, reply CONTEXT_SNAPSHOTS_WRITTEN. Otherwise reply ANNOUNCE_SKIP."
       },
@@ -167,7 +167,7 @@
       "payload": {
         "kind": "agentTurn",
         "message": "Run the conversation archive script to preserve conversation digests before session cleanup:\n\nbash /data/.openclaw/workspace/scripts/archive-conversations.sh\n\nThen trigger QMD reindex if available:\n\nif command -v qmd >/dev/null 2>&1; then qmd update && qmd embed; fi\n\nIf successful, reply with the archive counts. If nothing new, reply ANNOUNCE_SKIP.",
-        "model": "openai-codex/gpt-5.4",
+        "model": "openai-codex/gpt-5.3-codex",
         "timeoutSeconds": 120
       },
       "wakeMode": "next-heartbeat",

--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -35,20 +35,20 @@
   "agents": {
     "defaults": {
       "model": {
-        "primary": "openai-codex/gpt-5.5",
+        "primary": "openai-codex/gpt-5.4",
         "fallbacks": [
-          "openai-codex/gpt-5.4",
+          "openai-codex/gpt-5.3-codex",
           "anthropic/claude-opus-4-6",
-          "openrouter/openai/gpt-5.4-codex",
+          "openrouter/openai/gpt-5.2-codex",
           "anthropic/claude-sonnet-4-5"
         ]
       },
       "models": {
-        "openai-codex/gpt-5.5": {
+        "openai-codex/gpt-5.4": {
           "alias": "Codex"
         },
-        "openai-codex/gpt-5.4": {
-          "alias": "Codex-5.4"
+        "openai-codex/gpt-5.3-codex": {
+          "alias": "Codex-5.3"
         },
         "anthropic/claude-sonnet-4-5": {
           "alias": "Sonnet"
@@ -71,8 +71,8 @@
         "openrouter/mistralai/mistral-large-2512": {
           "alias": "MistralLarge"
         },
-        "openrouter/openai/gpt-5.4-codex": {
-          "alias": "Codex-OR-5.4"
+        "openrouter/openai/gpt-5.2-codex": {
+          "alias": "Codex-OR-5.2"
         }
       },
       "thinkingDefault": "adaptive",

--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -127,7 +127,7 @@
       "maxConcurrent": 4,
       "subagents": {
         "maxConcurrent": 8,
-        "runTimeoutSeconds": 3600,
+        "runTimeoutSeconds": 14400,
         "thinking": "high"
       },
       "sandbox": {

--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -35,16 +35,20 @@
   "agents": {
     "defaults": {
       "model": {
-        "primary": "openai-codex/gpt-5.4",
+        "primary": "openai-codex/gpt-5.5",
         "fallbacks": [
+          "openai-codex/gpt-5.4",
           "anthropic/claude-opus-4-6",
-          "openrouter/openai/gpt-5.2-codex",
+          "openrouter/openai/gpt-5.4-codex",
           "anthropic/claude-sonnet-4-5"
         ]
       },
       "models": {
-        "openai-codex/gpt-5.4": {
+        "openai-codex/gpt-5.5": {
           "alias": "Codex"
+        },
+        "openai-codex/gpt-5.4": {
+          "alias": "Codex-5.4"
         },
         "anthropic/claude-sonnet-4-5": {
           "alias": "Sonnet"
@@ -67,8 +71,8 @@
         "openrouter/mistralai/mistral-large-2512": {
           "alias": "MistralLarge"
         },
-        "openrouter/openai/gpt-5.2-codex": {
-          "alias": "Codex-OR-5.2"
+        "openrouter/openai/gpt-5.4-codex": {
+          "alias": "Codex-OR-5.4"
         }
       },
       "thinkingDefault": "adaptive",

--- a/remote/entrypoint.sh
+++ b/remote/entrypoint.sh
@@ -157,16 +157,19 @@ jq --argjson max_concurrent "$MAX_CONCURRENT" '
 # Preferred path is ChatGPT/Codex OAuth (`openai-codex/*`), backed by the
 # persisted Codex CLI login on /data. `OPENAI_API_KEY` stays available for
 # voice features only and is never used for gateway model routing.
-DEFAULT_PRIMARY_MODEL="openai-codex/gpt-5.4"
-DEFAULT_CRON_MODEL="openai-codex/gpt-5.4"
+DEFAULT_PRIMARY_MODEL="openai-codex/gpt-5.5"
+DEFAULT_CRON_MODEL="openai-codex/gpt-5.5"
 CLAUDE_CLI_AUTH_FILE="/data/.claude/.credentials.json"
 LEGACY_CLAUDE_AUTH_FILE="/data/.claude.json"
 DEFAULT_FALLBACK_MODELS=()
+if [ -f /data/.codex/auth.json ]; then
+    DEFAULT_FALLBACK_MODELS+=("openai-codex/gpt-5.4")
+fi
 if [ -f "$CLAUDE_CLI_AUTH_FILE" ] || [ -f "$LEGACY_CLAUDE_AUTH_FILE" ]; then
     DEFAULT_FALLBACK_MODELS+=("claude-cli/claude-sonnet-4-6")
 fi
 [ -n "${ANTHROPIC_API_KEY:-}" ] && DEFAULT_FALLBACK_MODELS+=("anthropic/claude-opus-4-6")
-[ -n "${OPENROUTER_API_KEY:-}" ] && DEFAULT_FALLBACK_MODELS+=("openrouter/openai/gpt-5.2-codex")
+[ -n "${OPENROUTER_API_KEY:-}" ] && DEFAULT_FALLBACK_MODELS+=("openrouter/openai/gpt-5.4-codex")
 DEFAULT_FALLBACK_MODELS_JSON="$(printf '%s\n' "${DEFAULT_FALLBACK_MODELS[@]:-}" | jq -R . | jq -s 'map(select(length > 0))')"
 
 if [ ! -f /data/.codex/auth.json ]; then
@@ -179,8 +182,8 @@ if [ ! -f /data/.codex/auth.json ]; then
         DEFAULT_CRON_MODEL="anthropic/claude-opus-4-6"
         echo "No Codex OAuth credentials found; defaulting primary to Anthropic API."
     elif [ -n "${OPENROUTER_API_KEY:-}" ]; then
-        DEFAULT_PRIMARY_MODEL="openrouter/openai/gpt-5.2-codex"
-        DEFAULT_CRON_MODEL="openrouter/openai/gpt-5.2-codex"
+        DEFAULT_PRIMARY_MODEL="openrouter/openai/gpt-5.4-codex"
+        DEFAULT_CRON_MODEL="openrouter/openai/gpt-5.4-codex"
         echo "No Codex/Anthropic credentials found; defaulting primary to OpenRouter."
     else
         echo "Warning: no Codex OAuth, Anthropic, or OpenRouter model credentials found."

--- a/remote/entrypoint.sh
+++ b/remote/entrypoint.sh
@@ -227,6 +227,10 @@ _patch_agent_settings() {
             then .agents.defaults.subagents.thinking = $seed.agents.defaults.subagents.thinking
             else .
          end) |
+        (if ($seed.agents.defaults.subagents.runTimeoutSeconds != null)
+            then .agents.defaults.subagents.runTimeoutSeconds = $seed.agents.defaults.subagents.runTimeoutSeconds
+            else .
+         end) |
         (if $seed.agents.defaults.contextTokens != null
             then .agents.defaults.contextTokens = $seed.agents.defaults.contextTokens
             else .

--- a/remote/entrypoint.sh
+++ b/remote/entrypoint.sh
@@ -157,19 +157,19 @@ jq --argjson max_concurrent "$MAX_CONCURRENT" '
 # Preferred path is ChatGPT/Codex OAuth (`openai-codex/*`), backed by the
 # persisted Codex CLI login on /data. `OPENAI_API_KEY` stays available for
 # voice features only and is never used for gateway model routing.
-DEFAULT_PRIMARY_MODEL="openai-codex/gpt-5.5"
-DEFAULT_CRON_MODEL="openai-codex/gpt-5.5"
+DEFAULT_PRIMARY_MODEL="openai-codex/gpt-5.4"
+DEFAULT_CRON_MODEL="openai-codex/gpt-5.3-codex"
 CLAUDE_CLI_AUTH_FILE="/data/.claude/.credentials.json"
 LEGACY_CLAUDE_AUTH_FILE="/data/.claude.json"
 DEFAULT_FALLBACK_MODELS=()
 if [ -f /data/.codex/auth.json ]; then
-    DEFAULT_FALLBACK_MODELS+=("openai-codex/gpt-5.4")
+    DEFAULT_FALLBACK_MODELS+=("openai-codex/gpt-5.3-codex")
 fi
 if [ -f "$CLAUDE_CLI_AUTH_FILE" ] || [ -f "$LEGACY_CLAUDE_AUTH_FILE" ]; then
     DEFAULT_FALLBACK_MODELS+=("claude-cli/claude-sonnet-4-6")
 fi
 [ -n "${ANTHROPIC_API_KEY:-}" ] && DEFAULT_FALLBACK_MODELS+=("anthropic/claude-opus-4-6")
-[ -n "${OPENROUTER_API_KEY:-}" ] && DEFAULT_FALLBACK_MODELS+=("openrouter/openai/gpt-5.4-codex")
+[ -n "${OPENROUTER_API_KEY:-}" ] && DEFAULT_FALLBACK_MODELS+=("openrouter/openai/gpt-5.2-codex")
 DEFAULT_FALLBACK_MODELS_JSON="$(printf '%s\n' "${DEFAULT_FALLBACK_MODELS[@]:-}" | jq -R . | jq -s 'map(select(length > 0))')"
 
 if [ ! -f /data/.codex/auth.json ]; then
@@ -182,8 +182,8 @@ if [ ! -f /data/.codex/auth.json ]; then
         DEFAULT_CRON_MODEL="anthropic/claude-opus-4-6"
         echo "No Codex OAuth credentials found; defaulting primary to Anthropic API."
     elif [ -n "${OPENROUTER_API_KEY:-}" ]; then
-        DEFAULT_PRIMARY_MODEL="openrouter/openai/gpt-5.4-codex"
-        DEFAULT_CRON_MODEL="openrouter/openai/gpt-5.4-codex"
+        DEFAULT_PRIMARY_MODEL="openrouter/openai/gpt-5.2-codex"
+        DEFAULT_CRON_MODEL="openrouter/openai/gpt-5.2-codex"
         echo "No Codex/Anthropic credentials found; defaulting primary to OpenRouter."
     else
         echo "Warning: no Codex OAuth, Anthropic, or OpenRouter model credentials found."

--- a/scripts/sandbox-up.sh
+++ b/scripts/sandbox-up.sh
@@ -33,7 +33,7 @@ fi
 # Select a safe default primary model based on available credentials.
 DEFAULT_PRIMARY_MODEL="anthropic/claude-opus-4-6"
 if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -n "${OPENROUTER_API_KEY:-}" ]; then
-    DEFAULT_PRIMARY_MODEL="openrouter/openai/gpt-5.2-codex"
+    DEFAULT_PRIMARY_MODEL="openrouter/openai/gpt-5.4-codex"
     echo "No Anthropic API key found; defaulting primary model to $DEFAULT_PRIMARY_MODEL"
 fi
 

--- a/scripts/sandbox-up.sh
+++ b/scripts/sandbox-up.sh
@@ -33,7 +33,7 @@ fi
 # Select a safe default primary model based on available credentials.
 DEFAULT_PRIMARY_MODEL="anthropic/claude-opus-4-6"
 if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -n "${OPENROUTER_API_KEY:-}" ]; then
-    DEFAULT_PRIMARY_MODEL="openrouter/openai/gpt-5.4-codex"
+    DEFAULT_PRIMARY_MODEL="openrouter/openai/gpt-5.2-codex"
     echo "No Anthropic API key found; defaulting primary model to $DEFAULT_PRIMARY_MODEL"
 fi
 


### PR DESCRIPTION
## Summary
- Keep the gateway primary on OpenClaw's canonical Codex OAuth model `openai-codex/gpt-5.4`.
- Use `openai-codex/gpt-5.3-codex` for the same-provider fallback and all repo-managed cron jobs.
- Revert OpenRouter fallback references to `openrouter/openai/gpt-5.2-codex`; remove invalid `gpt-5.5` and `gpt-5.4-codex` defaults from repo scripts/docs/config.

## Validated model mapping
- Gateway primary: `openai-codex/gpt-5.4` (OpenClaw source canonical model; `gpt-5.4-codex` is only a legacy alias normalized to `gpt-5.4`).
- Gateway same-provider fallback: `openai-codex/gpt-5.3-codex` (OpenClaw source-supported Codex model; also listed in OpenAI docs).
- Standard cron lane: `openai-codex/gpt-5.3-codex`.
- Lightweight cron lane: `openai-codex/gpt-5.3-codex-spark`.
- OpenRouter fallback: `openrouter/openai/gpt-5.2-codex` (OpenAI/OpenRouter-style Codex model ID; avoids the unsupported `gpt-5.4-codex`).

## Validation
- `grep -RInE 'gpt-5\\.5|gpt-5\\.4-codex' -- README.md CLAUDE.md .env.example config remote scripts` returns no matches.
- Verified all 6 seeded cron jobs use `openai-codex/gpt-5.3-codex`.
- `node` JSON parse for `config/openclaw.json` and `config/cron/jobs.json`.
- `bash -n remote/entrypoint.sh scripts/sandbox-up.sh`.
- `git diff --check`.
